### PR TITLE
Added CLAHE HE for 8bit images

### DIFF
--- a/cfg/alpha_blackfly/alpha_blackfly.info
+++ b/cfg/alpha_blackfly/alpha_blackfly.info
@@ -82,10 +82,10 @@ ImgUpdate
 	updateVecNormTermination 1e-4;
 	maxNumIteration 20; 35; 20;
     doPatchWarping true;										Should the patches be warped
-    doFrameVisualisation false;									Should the frames be visualized
+    doFrameVisualisation true;									Should the frames be visualized
     visualizePatches false;										Should the patches be visualized
     useDirectMethod true;										Should the EKF-innovation be based on direct intensity error (o.w. reprojection error)
-    startLevel 3;												Highest patch level which is being employed (must be smaller than the hardcoded template parameter)
+    startLevel 2;												Highest patch level which is being employed (must be smaller than the hardcoded template parameter)
     endLevel 1;													Lowest patch level which is being employed
     nDetectionBuckets 100;										Number of discretization buckets used during the candidates selection
     MahalanobisTh 9.21;											Mahalanobis treshold for the update, 5.8858356
@@ -178,7 +178,7 @@ Prediction
     {
         g_x 0.0;                                X-Component of gravity vector [m^2/s]
         g_y 0.0;                                Y-Component of gravity vector [m^2/s]
-        g_z -9.8754;                            Z-Component of gravity vector [m^2/s]
+        g_z -9.92; -9.8754;                     Z-Component of gravity vector [m^2/s]
     }
     MotionDetection
     {

--- a/cfg/charlie_tau2/charlie_tau2.info
+++ b/cfg/charlie_tau2/charlie_tau2.info
@@ -82,7 +82,7 @@ ImgUpdate
 	updateVecNormTermination 1e-4;
 	maxNumIteration 20; 35; 20;
     doPatchWarping true;										Should the patches be warped
-    doFrameVisualisation false;									Should the frames be visualized
+    doFrameVisualisation true;									Should the frames be visualized
     visualizePatches false;										Should the patches be visualized - 'Do not turn on if using 16-bit images'
     useDirectMethod true;										Should the EKF-innovation be based on direct intensity error (o.w. reprojection error)
     startLevel 2;												Highest patch level which is being employed (must be smaller than the hardcoded template parameter)
@@ -112,7 +112,7 @@ ImgUpdate
     minRelativeSTScore 0.75;    								Minimum relative ST-score for extracting new feature patch - The quality of new extracted patch for matching is atleast greater than 75% quality of old
     minAbsoluteSTScore 5.0;										Minimum absolute ST-score for extracting new feature patch
     minTimeBetweenPatchUpdate 1.0; 3.0; 5.0;  				    Minimum time between new multilevel patch extrection [s]
-    fastDetectionThreshold 5; 10; 5;   							Fast corner detector treshold while adding new feature
+    fastDetectionThreshold 10; 10; 5;  							Fast corner detector treshold while adding new feature
     alignConvergencePixelRange 10;								Assumed convergence range for image alignment (gets scaled with the level) [pixels]
     alignCoverageRatio 2;										How many sigma of the uncertainty should be covered in the adaptive alignement
     alignMaxUniSample 1;										Maximal number of alignment seeds on one side -> total number of sample = 2n+1. Carefull can get very costly if diverging!
@@ -123,7 +123,7 @@ ImgUpdate
     useIntensityOffsetForAlignment true;						Should an intensity offset between the patches be considered
     useIntensitySqewForAlignment true;							Should an intensity sqew between the patches be considered
     removeNegativeFeatureAfterUpdate true;						Should feature with negative distance get removed
-    maxUncertaintyToDepthRatioForDepthInitialization 0.3; 0.0; 0.3;  If set to 0.0 the depth is initialized with the standard value provided above, otherwise ROVIO attempts to figure out a median depth in each frame
+    maxUncertaintyToDepthRatioForDepthInitialization 0.3;       If set to 0.0 the depth is initialized with the standard value provided above, otherwise ROVIO attempts to figure out a median depth in each frame
     useCrossCameraMeasurements false;							Should cross measurements between frame be used. Might be turned of in calibration phase.
     doStereoInitialization false;								Should a stereo match be used for feature initialization.
     noiseGainForOffCamera 1.0;									Factor added on update noise if not main camera

--- a/include/rovio/ImagePyramid.hpp
+++ b/include/rovio/ImagePyramid.hpp
@@ -158,15 +158,15 @@ public:
     if (applyHistogramEqualization)
       equalizeHistogram(l, histEqualizedLevelImg);
     else
-      imgs_[l].convertTo(histEqualizedLevelImg, CV_8UC1);
+      imgs_[l].convertTo(histEqualizedLevelImg, CV_8UC1); //smk: needed as original input image is saved as float now, which is not accepted by FAST detector 
     //CUSTOMIZATION
 
 #if (CV_MAJOR_VERSION < 3)
     cv::FastFeatureDetector feature_detector_fast(detectionThreshold, true);
-    feature_detector_fast.detect(histEqualizedLevelImg, keypoints);
+    feature_detector_fast.detect(histEqualizedLevelImg, keypoints); //CUSTOMIZATION
 #else
     auto feature_detector_fast = cv::FastFeatureDetector::create(detectionThreshold, true);
-    feature_detector_fast->detect(histEqualizedLevelImg, keypoints);
+    feature_detector_fast->detect(histEqualizedLevelImg, keypoints); //CUSTOMIZATION
 #endif
 
     //Transform features between levels

--- a/launch/alpha_blackfly_rovio.launch
+++ b/launch/alpha_blackfly_rovio.launch
@@ -15,13 +15,17 @@
 
     <!-- Alpha - Blackfly-VN100 -->
     <param name="camera0_config" value="$(find rovio)/cfg/alpha_blackfly/alpha_blackfly.yaml"/>
-    <!-- <remap from="cam0/image_raw" to="/camera/image_raw"/> -->
-    <remap from="cam0/image_raw" to="/camera/image_mono"/>
+    <remap from="cam0/image_raw" to="/camera/image_raw"/>
+    <!-- <remap from="cam0/image_raw" to="/camera/image_mono"/> -->
     <param name="cam0_offset" value="0.01215371276812396"/> # blackfly: timeshift[s](t_imu = t_cam + shift) 0.01215371276812396 
     <param name="resize_input_image" value="true"/>         # resize input image by resize_factor - CAMERA INTRINSICS NOT SCALED CORRECT CALIBRATION FILE MANUALLY
     <param name="resize_factor" value="0.5"/>               # (img.cols x resize_factor) X (img.rows x resize_factor)
+    <param name="histogram_equalize_8bit_images" value="true"/>
+    <param name="clahe_clip_limit" value="2"/>
+    <param name="clahe_grid_size" value="6"/>
 
     <!-- ROVIO ODOMETRY POST PROCESSING -->
-    <!-- <remap from="rovio/odometry" to="/rotio/odometry"/> -->
+    <remap from="rovio/odometry" to="/rotio/odometry"/>
   </node>
+
 </launch>

--- a/launch/charlie_tau2_rovio.launch
+++ b/launch/charlie_tau2_rovio.launch
@@ -23,3 +23,6 @@
     <remap from="rovio/odometry" to="/rotio/odometry"/>  
   </node>
 </launch>
+
+<!-- ROVIO Pose reset service call format-->
+<!-- rosservice call /rovio/reset_to_pose ['{x: 2.0, y: 2.0, z: 2.0}','{x: 0.0, y: 0.0, z: 0.0, w: 1.0}'] -->


### PR DESCRIPTION
Added CLAHE histogram equalization for 8-bit intensity image. Tuned parameters for alpha and charlie drones. 

This has been tested on the arts building datasets.